### PR TITLE
centralize diagnostic sort across all commands

### DIFF
--- a/cmd/tslua/eval.go
+++ b/cmd/tslua/eval.go
@@ -136,26 +136,18 @@ func runEval(source string) error {
 		return err
 	}
 
-	semanticDiags := compiler.SortAndDeduplicateDiagnostics(
-		compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil),
-	)
+	semanticDiags := compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil)
 
 	results, transpileDiags := cfg.transpile(program, nil)
+
+	allDiags := mergeAndSortDiagnostics(semanticDiags, transpileDiags)
 
 	for _, r := range results {
 		rel, _ := filepath.Rel(tmpDir, r.FileName)
 		if strings.HasSuffix(rel, "main.ts") {
 			fmt.Print(r.Lua)
-			if len(semanticDiags) > 0 || len(transpileDiags) > 0 {
-				if len(semanticDiags) > 0 {
-					dw.FormatTSDiagnostics(os.Stderr, semanticDiags, tmpDir, cfg.stderrIsTerminal)
-				}
-				if len(transpileDiags) > 0 {
-					if len(semanticDiags) > 0 {
-						fmt.Fprintln(os.Stderr)
-					}
-					dw.FormatTSTLDiagnostics(os.Stderr, transpileDiags, tmpDir, cfg.diagFormat, cfg.stderrIsTerminal)
-				}
+			if len(allDiags) > 0 {
+				dw.FormatAllDiagnostics(os.Stderr, allDiags, tmpDir, cfg.diagFormat, cfg.stderrIsTerminal)
 			}
 			return nil
 		}

--- a/cmd/tslua/main.go
+++ b/cmd/tslua/main.go
@@ -464,15 +464,14 @@ func runOnce(cfg *buildConfig, host compiler.CompilerHost) error {
 
 	tBind := time.Now()
 
-	semanticDiags := compiler.SortAndDeduplicateDiagnostics(
-		compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil),
-	)
+	semanticDiags := compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil)
 
 	tCheck := time.Now()
 
 	results, transpileDiags := cfg.transpile(program, nil)
 
-	hasErrors := reportDiagnostics(cfg, semanticDiags, transpileDiags)
+	allDiags := mergeAndSortDiagnostics(semanticDiags, transpileDiags)
+	hasErrors := reportDiagnostics(cfg, allDiags)
 
 	noEmit := noEmitFlag || program.Options().NoEmit.IsTrue()
 	noEmitOnError := noEmitOnErrorFlag || program.Options().NoEmitOnError.IsTrue()
@@ -516,20 +515,19 @@ func msf(d time.Duration) float64 {
 	return float64(d.Microseconds()) / 1000
 }
 
-func reportDiagnostics(cfg *buildConfig, semanticDiags []*ast.Diagnostic, transpileDiags []*ast.Diagnostic) bool {
-	hasErrors := false
-	if len(semanticDiags) > 0 {
-		dw.FormatTSDiagnostics(os.Stderr, semanticDiags, cfg.cwd, cfg.stderrIsTerminal)
-		hasErrors = true
+// mergeAndSortDiagnostics combines pre-emit (TS) and transpiler (TSTL) diagnostics
+// into a single sorted, deduplicated slice. This is the centralized chokepoint for
+// diagnostic ordering across all command modes (CLI, eval, watch, server, wasm).
+func mergeAndSortDiagnostics(preEmitDiags, transpileDiags []*ast.Diagnostic) []*ast.Diagnostic {
+	return compiler.SortAndDeduplicateDiagnostics(append(preEmitDiags, transpileDiags...))
+}
+
+func reportDiagnostics(cfg *buildConfig, allDiags []*ast.Diagnostic) bool {
+	if len(allDiags) == 0 {
+		return false
 	}
-	if len(transpileDiags) > 0 {
-		if hasErrors {
-			fmt.Fprintln(os.Stderr)
-		}
-		dw.FormatTSTLDiagnostics(os.Stderr, transpileDiags, cfg.cwd, cfg.diagFormat, cfg.stderrIsTerminal)
-		hasErrors = true
-	}
-	return hasErrors
+	dw.FormatAllDiagnostics(os.Stderr, allDiags, cfg.cwd, cfg.diagFormat, cfg.stderrIsTerminal)
+	return true
 }
 
 func writeBundle(cfg *buildConfig, results []transpiler.TranspileResult) error {

--- a/cmd/tslua/server.go
+++ b/cmd/tslua/server.go
@@ -437,7 +437,7 @@ func handleInlineRequest(req serverRequest, luaTarget transpiler.LuaTarget) serv
 	// Pre-emit diagnostics (syntactic + semantic), matching ts.getPreEmitDiagnostics
 	syntacticDiags := compiler.Program_GetSyntacticDiagnostics(program, context.Background(), nil)
 	semanticDiags := compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil)
-	preEmitDiags := compiler.SortAndDeduplicateDiagnostics(append(syntacticDiags, semanticDiags...))
+	preEmitDiags := append(syntacticDiags, semanticDiags...)
 
 	// Transpile using the updated program
 	cfg := buildConfigFromRequest(req, sourceRoot, luaTarget)
@@ -447,7 +447,7 @@ func handleInlineRequest(req serverRequest, luaTarget transpiler.LuaTarget) serv
 	inlineOldProgram = program
 	inlineSourceRoot = sourceRoot
 
-	allDiags := compiler.SortAndDeduplicateDiagnostics(append(preEmitDiags, diags...))
+	allDiags := mergeAndSortDiagnostics(preEmitDiags, diags)
 	luaFiles := make(map[string]string, len(results))
 	sourceMaps := make(map[string]string, len(results))
 	for _, r := range results {
@@ -540,7 +540,7 @@ func transpileProjectInner(tsconfigPath string, luaTarget transpiler.LuaTarget, 
 
 	syntacticDiags := compiler.Program_GetSyntacticDiagnostics(program, context.Background(), nil)
 	semanticDiags := compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil)
-	preEmitDiags := compiler.SortAndDeduplicateDiagnostics(append(syntacticDiags, semanticDiags...))
+	preEmitDiags := append(syntacticDiags, semanticDiags...)
 
 	t5b := time.Now()
 
@@ -557,7 +557,7 @@ func transpileProjectInner(tsconfigPath string, luaTarget transpiler.LuaTarget, 
 			ms(t1.Sub(t0)), ms(t2.Sub(t1)), ms(t3.Sub(t2)), ms(t4.Sub(t3)), ms(t5.Sub(t4)), ms(t5b.Sub(t5)), ms(t6.Sub(t5b)), ms(t6.Sub(t0)))
 	}
 
-	allDiags := append(preEmitDiags, tsDiags...)
+	allDiags := mergeAndSortDiagnostics(preEmitDiags, tsDiags)
 	return program, results, allDiags, nil
 }
 

--- a/cmd/tslua/watch.go
+++ b/cmd/tslua/watch.go
@@ -42,14 +42,13 @@ func runWatch(cfg *buildConfig, host compiler.CompilerHost) error {
 	t0 := time.Now()
 	fmt.Fprintf(os.Stderr, "build starting at %s\n", t0.Format("03:04:05 PM"))
 
-	semanticDiags := compiler.SortAndDeduplicateDiagnostics(
-		incremental.Program_GetSemanticDiagnostics(incrProg, context.Background(), nil),
-	)
+	semanticDiags := incremental.Program_GetSemanticDiagnostics(incrProg, context.Background(), nil)
 	results, transpileDiags := cfg.transpile(program, nil)
 	for _, r := range results {
 		cachedResults[r.FileName] = r
 	}
-	hasErrors := reportDiagnostics(cfg, semanticDiags, transpileDiags)
+	allDiags := mergeAndSortDiagnostics(semanticDiags, transpileDiags)
+	hasErrors := reportDiagnostics(cfg, allDiags)
 	if !noEmit && (!noEmitOnError || !hasErrors) {
 		emitResults(cfg, results)
 	}
@@ -176,11 +175,8 @@ func runWatch(cfg *buildConfig, host compiler.CompilerHost) error {
 							incremental.Program_GetSemanticDiagnostics(incrProg, context.Background(), sf)...)
 					}
 				}
-				semanticDiags = compiler.SortAndDeduplicateDiagnostics(semanticDiags)
 			} else {
-				semanticDiags = compiler.SortAndDeduplicateDiagnostics(
-					incremental.Program_GetSemanticDiagnostics(incrProg, context.Background(), nil),
-				)
+				semanticDiags = incremental.Program_GetSemanticDiagnostics(incrProg, context.Background(), nil)
 			}
 
 			tCheck := time.Now()
@@ -192,7 +188,8 @@ func runWatch(cfg *buildConfig, host compiler.CompilerHost) error {
 
 			tTranspile := time.Now()
 
-			hasErrors := reportDiagnostics(cfg, semanticDiags, transpileDiags)
+			allDiags := mergeAndSortDiagnostics(semanticDiags, transpileDiags)
+			hasErrors := reportDiagnostics(cfg, allDiags)
 			if !noEmit && !hasErrors {
 				if changedFiles != nil {
 					emitResults(cfg, freshResults)
@@ -268,8 +265,11 @@ func runWatch(cfg *buildConfig, host compiler.CompilerHost) error {
 			fmt.Fprintf(os.Stderr, "build finished in %.2fms\n", msf(time.Since(t0)))
 
 			// Report transpile diagnostics immediately (they're already computed).
-			if len(transpileDiags) > 0 {
-				dw.FormatTSTLDiagnostics(os.Stderr, transpileDiags, cfg.cwd, cfg.diagFormat, cfg.stderrIsTerminal)
+			// Sort for consistent ordering even though we can't interleave with
+			// semantic diags (those arrive asynchronously below).
+			sortedTranspileDiags := mergeAndSortDiagnostics(nil, transpileDiags)
+			if len(sortedTranspileDiags) > 0 {
+				dw.FormatAllDiagnostics(os.Stderr, sortedTranspileDiags, cfg.cwd, cfg.diagFormat, cfg.stderrIsTerminal)
 			}
 
 			// Build incremental snapshot + check diagnostics in background.
@@ -289,14 +289,12 @@ func runWatch(cfg *buildConfig, host compiler.CompilerHost) error {
 								incremental.Program_GetSemanticDiagnostics(newIncrProg, context.Background(), sf)...)
 						}
 					}
-					semanticDiags = compiler.SortAndDeduplicateDiagnostics(semanticDiags)
 				} else {
-					semanticDiags = compiler.SortAndDeduplicateDiagnostics(
-						incremental.Program_GetSemanticDiagnostics(newIncrProg, context.Background(), nil),
-					)
+					semanticDiags = incremental.Program_GetSemanticDiagnostics(newIncrProg, context.Background(), nil)
 				}
-				if len(semanticDiags) > 0 {
-					dw.FormatTSDiagnostics(os.Stderr, semanticDiags, cfg.cwd, cfg.stderrIsTerminal)
+				sorted := mergeAndSortDiagnostics(semanticDiags, nil)
+				if len(sorted) > 0 {
+					dw.FormatAllDiagnostics(os.Stderr, sorted, cfg.cwd, cfg.diagFormat, cfg.stderrIsTerminal)
 				}
 				if timingFlag {
 					fmt.Fprintf(os.Stderr, "  diag(async): %7.2fms\n", msf(time.Since(tIncrStart)))

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -220,13 +221,17 @@ func transpile(tsCode string, wopts wasmOptions) transpileResult {
 	}
 	results, tsDiags := transpiler.TranspileProgramWithOptions(program, root, lt, nil, opts)
 
+	// Sort transpiler diagnostics for consistent ordering.
+	semanticDiags := compiler.Program_GetSemanticDiagnostics(program, context.Background(), nil)
+	allDiags := compiler.SortAndDeduplicateDiagnostics(append(semanticDiags, tsDiags...))
+
 	var luaOut strings.Builder
 	for _, r := range results {
 		luaOut.WriteString(r.Lua)
 	}
 
 	var diags []wasmDiagnostic
-	for _, d := range tsDiags {
+	for _, d := range allDiags {
 		if d.File() == nil {
 			continue
 		}

--- a/shim/diagnosticwriter/shim.go
+++ b/shim/diagnosticwriter/shim.go
@@ -121,6 +121,42 @@ func FormatTSTLDiagnostics(w io.Writer, diags []*ast.Diagnostic, cwd string, for
 	}
 }
 
+// IsTSTLDiagnostic returns true if the diagnostic was produced by the tslua transpiler
+// (as opposed to the TypeScript type checker).
+func IsTSTLDiagnostic(d *ast.Diagnostic) bool {
+	return d.MessageKey() == "TSTL"
+}
+
+// FormatAllDiagnostics writes a mixed slice of TS and TSTL diagnostics, interleaved
+// in the order they appear (caller should sort first). Each diagnostic is formatted
+// using the appropriate formatter based on its source.
+func FormatAllDiagnostics(w io.Writer, diags []*ast.Diagnostic, cwd string, format DiagnosticFormat, colorize bool) {
+	opts := &diagnosticwriter.FormattingOptions{
+		NewLine: "\n",
+		ComparePathsOptions: tspath.ComparePathsOptions{
+			CurrentDirectory: cwd,
+		},
+	}
+	for i, d := range diags {
+		if IsTSTLDiagnostic(d) {
+			if i > 0 && colorize {
+				fmt.Fprintln(w)
+			}
+			FormatTSTLDiagnostic(w, d, cwd, format, colorize)
+		} else {
+			if i > 0 && colorize {
+				fmt.Fprintln(w)
+			}
+			wrapped := diagnosticwriter.WrapASTDiagnostic(d)
+			if colorize {
+				diagnosticwriter.FormatDiagnosticWithColorAndContext(w, wrapped, opts)
+			} else {
+				diagnosticwriter.WriteFormatDiagnostic(w, wrapped, opts)
+			}
+		}
+	}
+}
+
 // writeHelp renders help text with "  help: " prefix, indenting continuation lines.
 func writeHelp(w io.Writer, help string, colorize bool) {
 	lines := strings.Split(help, "\n")


### PR DESCRIPTION
All command modes (CLI, eval, watch, server, wasm) now merge TS and TSTL diagnostics into a single sorted list via mergeAndSortDiagnostics, fixing unsorted transpiler diagnostics in eval/CLI/watch and the server cold path.